### PR TITLE
basic motion tests

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -19,9 +19,7 @@ jobs:
     - name: Build
       run: cargo build --verbose
     - name: Run tests
-      run: |
-        cargo test --all-features --workspace --verbose
-        cargo test --all-features --doc
+      run: RUST_BACKTRACE=full cargo test --all
     - name: Formatting checks
       run: cargo fmt --all --check
     - name: Linting checks

--- a/examples/linear_collision.rs
+++ b/examples/linear_collision.rs
@@ -50,6 +50,7 @@ fn main() {
                 // can only apply vertical control force when not free-falling
                 if !player.grounded {
                     move_force.y = 0.0;
+                    move_force.x *= 0.025;
                 }
                 player.apply_force(move_force);
             }

--- a/src/entity.rs
+++ b/src/entity.rs
@@ -18,7 +18,6 @@ const TIME_STEP: f32 = 0.01; // defines the interval of the physics calculation
 pub const DEFAULT_WINDOW: (u16, u16) = (50, 10); // defines the viewing area and physical boundary
 const MAX_VEL: f32 = 20.0;
 const MAX_ACC: f32 = 1_000.0;
-const MAX_FORCE: f32 = 5_000.0;
 const _MAX_MASS: f32 = 1_000.0;
 
 // initialise the window boundary once at runtime by checking the size of the terminal
@@ -124,8 +123,6 @@ impl Entity {
     pub fn apply_force(&mut self, force: EuclidianVector) {
         self.input_force.x += force.x;
         self.input_force.y += force.y;
-        constraint(&mut self.input_force.x, -MAX_FORCE, MAX_FORCE);
-        constraint(&mut self.input_force.y, -MAX_FORCE, MAX_FORCE);
     }
 
     /// returns the force required to drive the entity to the target acceleration
@@ -142,8 +139,15 @@ impl Entity {
     }
 
     /// returns the force required to drive the entity to the target position
+    /// https://www.ncl.ac.uk/webtemplate/ask-assets/external/maths-resources/mechanics/kinematics/equations-of-motion.html
     pub fn target_pos(&mut self, x: f32, y: f32) -> EuclidianVector {
-        self.target_vel((x - self.pos.0) / TIME_STEP, (self.pos.1 - y) / TIME_STEP)
+        let (x0, y0) = self.pos;
+        let (vx, vy) = (self.vel.x, self.vel.y);
+        let m = self.mass;
+        EuclidianVector::new(
+            (2.0 / 3.0 ) * (x - x0 - (vx * TIME_STEP) ) * m / ( TIME_STEP * TIME_STEP ),
+            (2.0 / 3.0 ) * (y - y0 - (vy * TIME_STEP) ) * m / ( TIME_STEP * TIME_STEP )
+        )
     }
 
     /// update entity position using motion equations and Newton's 2nd Law:

--- a/src/entity.rs
+++ b/src/entity.rs
@@ -145,8 +145,8 @@ impl Entity {
         let (vx, vy) = (self.vel.x, self.vel.y);
         let m = self.mass;
         EuclidianVector::new(
-            (2.0 / 3.0 ) * (x - x0 - (vx * TIME_STEP) ) * m / ( TIME_STEP * TIME_STEP ),
-            (2.0 / 3.0 ) * (y - y0 - (vy * TIME_STEP) ) * m / ( TIME_STEP * TIME_STEP )
+            (2.0 / 3.0) * (x - x0 - (vx * TIME_STEP)) * m / (TIME_STEP * TIME_STEP),
+            (2.0 / 3.0) * (y - y0 - (vy * TIME_STEP)) * m / (TIME_STEP * TIME_STEP),
         )
     }
 

--- a/tests/entity_motion.rs
+++ b/tests/entity_motion.rs
@@ -1,0 +1,24 @@
+#[cfg(test)]
+mod test_entity_motion {
+    use ascii_arcade::entity::{vector::EuclidianVector, *};
+    #[test]
+    fn test_target_pos() {
+        let mut entity = Entity::new(EntityType::Npc, (2.0, 2.0));
+        let expect: (f32, f32) = (30.0, 2.0);
+        let force = entity.target_pos(expect.0, expect.1);
+        entity.apply_force(force);
+        entity.update();
+
+        assert_eq!(entity.pos, expect);
+    }
+    #[test]
+    fn test_target_vel() {
+        let mut entity = Entity::new(EntityType::Npc, (2.0, 2.0));
+        let expect = EuclidianVector::new(10.0, 0.0);
+        let force = entity.target_vel(expect.x, expect.y);
+        entity.apply_force(force);
+        entity.update();
+
+        assert_eq!(entity.vel, expect);
+    }
+}

--- a/tests/entity_motion.rs
+++ b/tests/entity_motion.rs
@@ -4,10 +4,11 @@ mod test_entity_motion {
     #[test]
     fn test_target_pos_x_same_initial_xy() {
         let initial: (f32, f32) = (5.0, 5.0);
-        for i in 1 .. 50 { // test from 1-to-5 in steps of 0.1 with a two-decimal resolution
+        for i in 1..50 {
+            // test from 1-to-5 in steps of 0.1 with a two-decimal resolution
             let mut entity = Entity::new(EntityType::Npc, initial);
             let i = 100.0 * (i as f32 * 0.1).round() / 100.0;
-            let expected = (initial.0 + i as f32, initial.1);
+            let expected = (initial.0 + i, initial.1);
             let force = entity.target_pos(expected.0, expected.1);
             entity.apply_force(force.clone());
             entity.update();
@@ -17,10 +18,11 @@ mod test_entity_motion {
     #[test]
     fn test_target_pos_y_same_initial_xy() {
         let initial: (f32, f32) = (5.0, 2.0);
-        for i in 1 .. 50 { // test from 1-to-5 in steps of 0.1 with a two-decimal resolution
+        for i in 1..50 {
+            // test from 1-to-5 in steps of 0.1 with a two-decimal resolution
             let mut entity = Entity::new(EntityType::Npc, initial);
             let i = 100.0 * (i as f32 * 0.1).round() / 100.0;
-            let expected = (initial.0, initial.1 + i as f32);
+            let expected = (initial.0, initial.1 + i);
             let force = entity.target_pos(expected.0, expected.1);
             entity.apply_force(force.clone());
             entity.update();
@@ -30,10 +32,11 @@ mod test_entity_motion {
     #[test]
     fn test_target_pos_x_different_initial_xy() {
         let initial: (f32, f32) = (40.0, 10.0);
-        for i in 1 .. 50 { // test from 1-to-5 in steps of 0.1 with a two-decimal resolution
+        for i in 1..50 {
+            // test from 1-to-5 in steps of 0.1 with a two-decimal resolution
             let mut entity = Entity::new(EntityType::Npc, initial);
             let i = 100.0 * (i as f32 * 0.1).round() / 100.0;
-            let expected = (initial.0 - i as f32, initial.1);
+            let expected = (initial.0 - i, initial.1);
             let force = entity.target_pos(expected.0, expected.1);
             entity.apply_force(force.clone());
             entity.update();
@@ -43,10 +46,11 @@ mod test_entity_motion {
     #[test]
     fn test_target_pos_y_different_initial_xy() {
         let initial: (f32, f32) = (10.0, 10.0);
-        for i in 1 .. 50 { // test from 1-to-5 in steps of 0.1 with a two-decimal resolution
+        for i in 1..50 {
+            // test from 1-to-5 in steps of 0.1 with a two-decimal resolution
             let mut entity = Entity::new(EntityType::Npc, initial);
             let i = 100.0 * (i as f32 * 0.1).round() / 100.0;
-            let expected = (initial.0 , initial.1 - i as f32);
+            let expected = (initial.0, initial.1 - i);
             let force = entity.target_pos(expected.0, expected.1);
             entity.apply_force(force.clone());
             entity.update();

--- a/tests/entity_motion.rs
+++ b/tests/entity_motion.rs
@@ -31,30 +31,34 @@ mod test_entity_motion {
     }
     #[test]
     fn test_target_pos_x_different_initial_xy() {
-        let initial: (f32, f32) = (40.0, 10.0);
-        for i in 1..50 {
-            // test from 1-to-5 in steps of 0.1 with a two-decimal resolution
-            let mut entity = Entity::new(EntityType::Npc, initial);
-            let i = 100.0 * (i as f32 * 0.1).round() / 100.0;
-            let expected = (initial.0 - i, initial.1);
-            let force = entity.target_pos(expected.0, expected.1);
-            entity.apply_force(force.clone());
-            entity.update();
-            assert_eq!(entity.pos, expected);
+        {
+            let initial: (f32, f32) = (8.0, 7.0);
+            for i in 1..50 {
+                // test from 1-to-5 in steps of 0.1 with a two-decimal resolution
+                let mut entity = Entity::new(EntityType::Npc, initial);
+                let i = 100.0 * (i as f32 * 0.1).round() / 100.0;
+                let expected = (initial.0 - i, initial.1);
+                let force = entity.target_pos(expected.0, expected.1);
+                entity.apply_force(force.clone());
+                entity.update();
+                assert_eq!(entity.pos, expected);
+            }
         }
     }
     #[test]
     fn test_target_pos_y_different_initial_xy() {
-        let initial: (f32, f32) = (10.0, 10.0);
-        for i in 1..50 {
-            // test from 1-to-5 in steps of 0.1 with a two-decimal resolution
-            let mut entity = Entity::new(EntityType::Npc, initial);
-            let i = 100.0 * (i as f32 * 0.1).round() / 100.0;
-            let expected = (initial.0, initial.1 - i);
-            let force = entity.target_pos(expected.0, expected.1);
-            entity.apply_force(force.clone());
-            entity.update();
-            assert_eq!(entity.pos, expected);
+        {
+            let initial: (f32, f32) = (8.0, 7.0);
+            for i in 1..50 {
+                // test from 1-to-5 in steps of 0.1 with a two-decimal resolution
+                let mut entity = Entity::new(EntityType::Npc, initial);
+                let i = 100.0 * (i as f32 * 0.1).round() / 100.0;
+                let expected = (initial.0, initial.1 - i);
+                let force = entity.target_pos(expected.0, expected.1);
+                entity.apply_force(force.clone());
+                entity.update();
+                assert_eq!(entity.pos, expected);
+            }
         }
     }
     #[test]

--- a/tests/entity_motion.rs
+++ b/tests/entity_motion.rs
@@ -2,14 +2,56 @@
 mod test_entity_motion {
     use ascii_arcade::entity::{vector::EuclidianVector, *};
     #[test]
-    fn test_target_pos() {
-        let mut entity = Entity::new(EntityType::Npc, (2.0, 2.0));
-        let expect: (f32, f32) = (30.0, 2.0);
-        let force = entity.target_pos(expect.0, expect.1);
-        entity.apply_force(force);
-        entity.update();
-
-        assert_eq!(entity.pos, expect);
+    fn test_target_pos_x_same_initial_xy() {
+        let initial: (f32, f32) = (5.0, 5.0);
+        for i in 1 .. 50 { // test from 1-to-5 in steps of 0.1 with a two-decimal resolution
+            let mut entity = Entity::new(EntityType::Npc, initial);
+            let i = 100.0 * (i as f32 * 0.1).round() / 100.0;
+            let expected = (initial.0 + i as f32, initial.1);
+            let force = entity.target_pos(expected.0, expected.1);
+            entity.apply_force(force.clone());
+            entity.update();
+            assert_eq!(entity.pos, expected);
+        }
+    }
+    #[test]
+    fn test_target_pos_y_same_initial_xy() {
+        let initial: (f32, f32) = (5.0, 2.0);
+        for i in 1 .. 50 { // test from 1-to-5 in steps of 0.1 with a two-decimal resolution
+            let mut entity = Entity::new(EntityType::Npc, initial);
+            let i = 100.0 * (i as f32 * 0.1).round() / 100.0;
+            let expected = (initial.0, initial.1 + i as f32);
+            let force = entity.target_pos(expected.0, expected.1);
+            entity.apply_force(force.clone());
+            entity.update();
+            assert_eq!(entity.pos, expected);
+        }
+    }
+    #[test]
+    fn test_target_pos_x_different_initial_xy() {
+        let initial: (f32, f32) = (40.0, 10.0);
+        for i in 1 .. 50 { // test from 1-to-5 in steps of 0.1 with a two-decimal resolution
+            let mut entity = Entity::new(EntityType::Npc, initial);
+            let i = 100.0 * (i as f32 * 0.1).round() / 100.0;
+            let expected = (initial.0 - i as f32, initial.1);
+            let force = entity.target_pos(expected.0, expected.1);
+            entity.apply_force(force.clone());
+            entity.update();
+            assert_eq!(entity.pos, expected);
+        }
+    }
+    #[test]
+    fn test_target_pos_y_different_initial_xy() {
+        let initial: (f32, f32) = (10.0, 10.0);
+        for i in 1 .. 50 { // test from 1-to-5 in steps of 0.1 with a two-decimal resolution
+            let mut entity = Entity::new(EntityType::Npc, initial);
+            let i = 100.0 * (i as f32 * 0.1).round() / 100.0;
+            let expected = (initial.0 , initial.1 - i as f32);
+            let force = entity.target_pos(expected.0, expected.1);
+            entity.apply_force(force.clone());
+            entity.update();
+            assert_eq!(entity.pos, expected);
+        }
     }
     #[test]
     fn test_target_vel() {

--- a/tests/entity_motion.rs
+++ b/tests/entity_motion.rs
@@ -62,13 +62,63 @@ mod test_entity_motion {
         }
     }
     #[test]
-    fn test_target_vel() {
-        let mut entity = Entity::new(EntityType::Npc, (2.0, 2.0));
-        let expect = EuclidianVector::new(10.0, 0.0);
-        let force = entity.target_vel(expect.x, expect.y);
-        entity.apply_force(force);
-        entity.update();
-
-        assert_eq!(entity.vel, expect);
+    fn test_target_vel_x_same_initial_xy() {
+        let initial: (f32, f32) = (5.0, 5.0);
+        for i in 1..50 {
+            // test from 1-to-5 in steps of 0.1 with a two-decimal resolution
+            let mut entity = Entity::new(EntityType::Npc, initial);
+            let i = 100.0 * (i as f32 * 0.1).round() / 100.0;
+            let expected = EuclidianVector::new(initial.0 + i, initial.1);
+            let force = entity.target_vel(expected.x, expected.y);
+            entity.apply_force(force.clone());
+            entity.update();
+            assert_eq!(entity.vel, expected);
+        }
+    }
+    #[test]
+    fn test_target_vel_y_same_initial_xy() {
+        let initial: (f32, f32) = (5.0, 5.0);
+        for i in 1..50 {
+            // test from 1-to-5 in steps of 0.1 with a two-decimal resolution
+            let mut entity = Entity::new(EntityType::Npc, initial);
+            let i = 100.0 * (i as f32 * 0.1).round() / 100.0;
+            let expected = EuclidianVector::new(initial.0, initial.1 + i);
+            let force = entity.target_vel(expected.x, expected.y);
+            entity.apply_force(force.clone());
+            entity.update();
+            assert_eq!(entity.vel, expected);
+        }
+    }
+    #[test]
+    fn test_target_vel_x_different_initial_xy() {
+        {
+            let initial: (f32, f32) = (8.0, 7.0);
+            for i in 1..50 {
+                // test from 1-to-5 in steps of 0.1 with a two-decimal resolution
+                let mut entity = Entity::new(EntityType::Npc, initial);
+                let i = 100.0 * (i as f32 * 0.1).round() / 100.0;
+                let expected = EuclidianVector::new(initial.0 - i, initial.1);
+                let force = entity.target_vel(expected.x, expected.y);
+                entity.apply_force(force.clone());
+                entity.update();
+                assert_eq!(entity.vel, expected);
+            }
+        }
+    }
+    #[test]
+    fn test_target_vel_y_different_initial_xy() {
+        {
+            let initial: (f32, f32) = (8.0, 7.0);
+            for i in 1..50 {
+                // test from 1-to-5 in steps of 0.1 with a two-decimal resolution
+                let mut entity = Entity::new(EntityType::Npc, initial);
+                let i = 100.0 * (i as f32 * 0.1).round() / 100.0;
+                let expected = EuclidianVector::new(initial.0, initial.1 - i);
+                let force = entity.target_vel(expected.x, expected.y);
+                entity.apply_force(force.clone());
+                entity.update();
+                assert_eq!(entity.vel, expected);
+            }
+        }
     }
 }


### PR DESCRIPTION
# Rationale :seedling:
<!-- An overview of why the PR is necessary (answers "why") -->
> Why are these changes necessary?
- The `Entity.target_xyz()` methods should be the primary interface for driving `Entity` state, rather than overriding motion parameters directly-- however they are not yet reliable for this purpose, so further unit-test coverage is necessary.
- The end-goal is to contrive a system that balances force-equations inherently, so motion attributes do not need to be overridden for edge-cases -- or, at least, to the extent that is reasonably possible.
- To mitigate entities from clipping through each other, a simple approach of moving entities by their overlap distance is currently used; but because this kind of "manual" approach is not contributing to the force equations, it completely ignores them, resulting in the the bouncing behavior shown by the red entities below -- which cannot be rectified through force-balancing:
![Peek 2025-03-16 17-23](https://github.com/user-attachments/assets/738edf24-a5ff-487d-836f-31ebd2f567e7)


# Summary :building_construction:
<!-- An overview of the core changes introduced by this PR (answers "what") -->
> What changes have been introduced?

- unit-tests for `Entity.target_pos()` and `Entity.target_vel()`
- minor qol change to `linear_collision` demo

# Testing :microscope:
<!-- Capture any testing activity used to validate code behavior -->
> How have the effects of these changes been verified?

- tested manually, no significant changes to demonstrate
